### PR TITLE
Add API authorization via BearerToken

### DIFF
--- a/APNPromise/APNPromise/APNPromise.csproj
+++ b/APNPromise/APNPromise/APNPromise.csproj
@@ -7,12 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
   </ItemGroup>
 
 </Project>

--- a/APNPromise/APNPromise/Configuration/BearerTokenOptions.cs
+++ b/APNPromise/APNPromise/Configuration/BearerTokenOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace APNPromise.Configuration
+{
+    public static class BearerTokenOptions
+    {
+        public const string SigningKey = "BjaSRAjrXeZr6cCX5aY5qQRq6vfmlqr4cLVu8xYQzbfAoIGmyRCjtQ669sj0ChOG";
+        public const string Audience = "audience";
+        public const string Issuer = "issuer";
+        public const bool ValidateSigningKey = true;
+    }
+}

--- a/APNPromise/APNPromise/Controllers/AccountController.cs
+++ b/APNPromise/APNPromise/Controllers/AccountController.cs
@@ -1,0 +1,30 @@
+﻿using APNPromise.Models;
+using APNPromise.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace APNPromise.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AccountController : ControllerBase
+    {
+        private readonly AccountService _accountService;
+
+        public AccountController(AccountService accountService)
+        {
+            _accountService = accountService;
+        }
+
+        [HttpPost("login")]
+        [AllowAnonymous]
+        public IActionResult LoginUser([FromBody] LoginRequest loginData)
+        {
+            var result = _accountService.LoginUser(loginData);
+            if (result == null)
+                return Unauthorized();
+            else
+                return Ok(result);
+        }
+    }
+}

--- a/APNPromise/APNPromise/Controllers/BooksController.cs
+++ b/APNPromise/APNPromise/Controllers/BooksController.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using APNPromise.Models;
+using Microsoft.AspNetCore.Authorization;
 
 namespace APNPromise.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class BooksController : ControllerBase
     {
         private readonly BooksContext _context;

--- a/APNPromise/APNPromise/Controllers/OrdersController.cs
+++ b/APNPromise/APNPromise/Controllers/OrdersController.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using APNPromise.Models;
+using Microsoft.AspNetCore.Authorization;
 
 namespace APNPromise.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class OrdersController : ControllerBase
     {
         private readonly OrdersContext _context;

--- a/APNPromise/APNPromise/Models/LoginRequest.cs
+++ b/APNPromise/APNPromise/Models/LoginRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace APNPromise.Models
+{
+    public class LoginRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/APNPromise/APNPromise/Models/Token.cs
+++ b/APNPromise/APNPromise/Models/Token.cs
@@ -1,0 +1,7 @@
+﻿namespace APNPromise.Models
+{
+    public class Token
+    {
+        public string AccessToken { get; set; }
+    }
+}

--- a/APNPromise/APNPromise/Program.cs
+++ b/APNPromise/APNPromise/Program.cs
@@ -1,19 +1,73 @@
+using System.Text;
+using APNPromise.Configuration;
 using APNPromise.Models;
+using APNPromise.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(o =>
+    {
+        o.TokenValidationParameters = new TokenValidationParameters
+        {
+            ClockSkew = TimeSpan.Zero,
+            IgnoreTrailingSlashWhenValidatingAudience = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(BearerTokenOptions.SigningKey)),
+            ValidateIssuerSigningKey = true,
+            RequireExpirationTime = true,
+            RequireAudience = true,
+            RequireSignedTokens = true,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateLifetime = true,
+            ValidAudience = BearerTokenOptions.Audience,
+            ValidIssuer = BearerTokenOptions.Issuer
+        };
+        o.Authority = "http://localhost:7205";
+        o.RequireHttpsMetadata = false;
+        o.SaveToken = true;
+    });
 
 builder.Services.AddDbContext<BooksContext>(opt =>
     opt.UseInMemoryDatabase("BooksList"));
 builder.Services.AddDbContext<OrdersContext>(opt =>
     opt.UseInMemoryDatabase("OrdersList"));
 
+builder.Services.AddScoped<BearerTokenService>();
+builder.Services.AddScoped<AccountService>();
+
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(setup =>
+{
+    var jwtSecurityScheme = new OpenApiSecurityScheme
+    {
+        BearerFormat = "JWT",
+        Name = "JWT Token",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.Http,
+        Scheme = JwtBearerDefaults.AuthenticationScheme,
+
+        Reference = new OpenApiReference
+        {
+            Id = JwtBearerDefaults.AuthenticationScheme,
+            Type = ReferenceType.SecurityScheme
+        }
+    };
+
+    setup.AddSecurityDefinition(jwtSecurityScheme.Reference.Id, jwtSecurityScheme);
+
+    setup.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { jwtSecurityScheme, Array.Empty<string>() }
+    });
+
+});
 
 var app = builder.Build();
 
@@ -26,6 +80,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/APNPromise/APNPromise/Services/AccountService.cs
+++ b/APNPromise/APNPromise/Services/AccountService.cs
@@ -1,0 +1,26 @@
+﻿using APNPromise.Models;
+
+namespace APNPromise.Services
+{
+    public class AccountService
+    {
+        private readonly BearerTokenService _bearerTokenService;
+        public AccountService(BearerTokenService bearerTokenService)
+        {
+            _bearerTokenService = bearerTokenService;
+        }
+
+        public Token LoginUser(LoginRequest loginData)
+        {
+            if (loginData.Username == "username" && loginData.Password == "password")
+            {
+                var result = new Token();
+                result.AccessToken = _bearerTokenService.GenerateBearerToken();
+
+                return result;
+            }
+            else
+                return null;
+        }
+    }
+}

--- a/APNPromise/APNPromise/Services/BearerTokenService.cs
+++ b/APNPromise/APNPromise/Services/BearerTokenService.cs
@@ -1,0 +1,39 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
+using System.Text;
+using APNPromise.Configuration;
+
+namespace APNPromise.Services
+{
+    public class BearerTokenService
+    {
+        public string GenerateBearerToken()
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(BearerTokenOptions.SigningKey));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+            var expiry = DateTimeOffset.Now.AddMinutes(15);
+            var userClaims = GetClaimsForUser(1);
+
+            var securityToken = new JwtSecurityToken(
+                issuer: BearerTokenOptions.Issuer,
+                audience: BearerTokenOptions.Audience,
+                claims: userClaims,
+                notBefore: DateTime.Now,
+                expires: expiry.DateTime,
+                signingCredentials: credentials);
+
+            return new JwtSecurityTokenHandler().WriteToken(securityToken);
+        }
+
+        private IEnumerable<Claim> GetClaimsForUser(int userId)
+        {
+            var claims = new List<Claim>();
+            claims.Add(new Claim(ClaimTypes.Email, "test@dev.com"));
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+            claims.Add(new Claim(ClaimTypes.Role, "dev"));
+
+            return claims;
+        }
+    }
+}


### PR DESCRIPTION
Included Microsoft JWTBearer package
Decorated already existing API with [Authorize] attribute
Added BearerTokenService for returning BearerToken
Added AccountService and LoginRequest model for BearerToken acqusition
Added AccountController with "login" endpoint for authentication purposes
Added "Authorize" option to Swagger to provide BearerToken for API authorization

NOTE: For dev purposes credentials used for login are "username"/"password"